### PR TITLE
Could not resolve host: av7eQ6L

### DIFF
--- a/PULL_REQUESTS/whitelist.list
+++ b/PULL_REQUESTS/whitelist.list
@@ -1,6 +1,7 @@
 1.0.0.1
 1.1.1.1
 ALL .mypdns.org
+ALL .mypdns.com
 106c06cd218b007d-b1e8a1331f68446599e96a4b46a050f5.ams.plex.services
 151.101.38.49
 1fichier.com


### PR DESCRIPTION
fatal: unable to access 'https://[secure]@github.com/spirillen/rpz-block-list.git/': Could not resolve host: av7eQ6L

testing with `ALL .mypdns.com`


