### PR TITLE
dickssportinggoods.com #33

### DIFF
--- a/PULL_REQUESTS/whitelist.list
+++ b/PULL_REQUESTS/whitelist.list
@@ -186,6 +186,7 @@ digitaltrends.com
 directvnow.com
 discovermagazine.com
 discussions.apple.com
+dickssportinggoods.com
 displaycatalog.mp.microsoft.com
 disqus.com
 dl-client.dropbox.com


### PR DESCRIPTION
dickssportinggoods.com should be whitelisted from issue #33 

closes #33


